### PR TITLE
Feat: Markets, transactions - Changes: core deps

### DIFF
--- a/markstr-core/Cargo.toml
+++ b/markstr-core/Cargo.toml
@@ -12,8 +12,8 @@ categories.workspace = true
 
 [dependencies]
 # Core Bitcoin functionality
-bitcoin.workspace = true
-nostr.workspace = true
+bitcoin = { workspace = true, features = ["rand-std", "serde"] }
+# nostr.workspace = true
 
 # Cryptography
 secp256k1.workspace = true
@@ -33,7 +33,7 @@ uuid.workspace = true
 chrono.workspace = true
 
 # Async runtime
-tokio.workspace = true
+# tokio.workspace = true
 
 [features]
 default = ["std"]

--- a/markstr-core/src/error.rs
+++ b/markstr-core/src/error.rs
@@ -10,7 +10,15 @@ pub type Result<T> = std::result::Result<T, MarketError>;
 pub enum MarketError {
     /// Bitcoin-related errors
     #[error("Bitcoin error: {0}")]
-    Bitcoin(#[from] bitcoin::Error),
+    BitcoinHex(#[from] bitcoin::error::PrefixedHexError),
+
+    /// Bitcoin-related errors
+    #[error("Bitcoin error: {0}")]
+    Bitcoin(#[from] bitcoin::error::UnprefixedHexError),
+
+    /// Taproot errors
+    #[error("Taproot error: {0}")]
+    TaprootBuilderError(#[from] bitcoin::taproot::TaprootBuilderError),
 
     /// Secp256k1 errors
     #[error("Secp256k1 error: {0}")]
@@ -25,8 +33,8 @@ pub enum MarketError {
     Json(#[from] serde_json::Error),
 
     /// Nostr errors
-    #[error("Nostr error: {0}")]
-    Nostr(#[from] nostr::Error),
+    // #[error("Nostr error: {0}")]
+    // Nostr(#[from] nostr::Error),
 
     /// Market validation errors
     #[error("Invalid market: {0}")]
@@ -67,12 +75,13 @@ pub enum MarketError {
 
 impl From<&str> for MarketError {
     fn from(msg: &str) -> Self {
-        MarketError::Other(msg.to_string())
+        Self::Other(msg.to_string())
     }
 }
 
 impl From<String> for MarketError {
     fn from(msg: String) -> Self {
-        MarketError::Other(msg)
+        Self::Other(msg)
     }
 }
+

--- a/markstr-core/src/lib.rs
+++ b/markstr-core/src/lib.rs
@@ -6,7 +6,7 @@
 //! prediction markets where:
 //! - Markets are created and settled using Nostr events
 //! - Funds are held in Bitcoin Taproot addresses
-//! - Payouts are verified using CSFS (CheckSigFromStack) signatures
+//! - Payouts are verified using CSFS (```CheckSigFromStack```) signatures
 //!
 //! ## Features
 //!
@@ -37,16 +37,17 @@
 
 pub mod error;
 pub mod market;
-pub mod nostr;
+// pub mod nostr;
 pub mod utils;
 
 pub use error::{MarketError, Result};
 pub use market::{Bet, PredictionMarket};
-pub use nostr::NostrClient;
+// pub use nostr::NostrClient;
 pub use utils::*;
 
 /// Default fee for market transactions (1000 satoshis)
 pub const DEFAULT_MARKET_FEE: u64 = 1000;
 
-/// OP_CHECKSIGFROMSTACK opcode (0xcc)
+/// ```OP_CHECKSIGFROMSTACK``` opcode (0xcc)
 pub const OP_CHECKSIGFROMSTACK: u8 = 0xcc;
+

--- a/markstr-core/src/utils.rs
+++ b/markstr-core/src/utils.rs
@@ -86,12 +86,14 @@ pub fn verify_signature(message: &str, signature: &str, pubkey: &str) -> Result<
 }
 
 /// Network enum to u8 conversion
-pub fn network_to_u8(network: Network) -> u8 {
+pub const fn network_to_u8(network: Network) -> u8 {
     match network {
         Network::Bitcoin => 0,
         Network::Testnet => 1,
         Network::Signet => 2,
         Network::Regtest => 3,
+        Network::Testnet4 => 4,
+        _ => 5,
     }
 }
 
@@ -102,15 +104,15 @@ pub fn u8_to_network(network: u8) -> Result<Network> {
         1 => Ok(Network::Testnet),
         2 => Ok(Network::Signet),
         3 => Ok(Network::Regtest),
-        _ => Err(MarketError::Network(format!("Invalid network: {}", network))),
+        4 => Ok(Network::Testnet4),
+        _ => Err(MarketError::Network(format!("Invalid network: {network}"))),
     }
 }
 
 /// Format timestamp as human-readable string
 pub fn format_timestamp(timestamp: u64) -> String {
-    use chrono::{DateTime, Utc};
-    let dt = DateTime::from_timestamp(timestamp as i64, 0)
-        .unwrap_or_else(|| DateTime::from_timestamp(0, 0).unwrap());
+    use chrono::DateTime;
+    let dt = DateTime::from_timestamp(timestamp as i64, 0).unwrap_or_default();
     dt.format("%Y-%m-%d %H:%M:%S UTC").to_string()
 }
 
@@ -118,7 +120,7 @@ pub fn format_timestamp(timestamp: u64) -> String {
 pub fn parse_timestamp(timestamp_str: &str) -> Result<u64> {
     timestamp_str
         .parse::<u64>()
-        .map_err(|_| MarketError::Other(format!("Invalid timestamp: {}", timestamp_str)))
+        .map_err(|_| MarketError::Other(format!("Invalid timestamp: {timestamp_str}")))
 }
 
 #[cfg(test)]
@@ -160,3 +162,4 @@ mod tests {
         assert!(!validate_address(invalid_addr, Network::Bitcoin));
     }
 }
+

--- a/markstr-wasm/src/lib.rs
+++ b/markstr-wasm/src/lib.rs
@@ -271,7 +271,7 @@ pub fn sha256_hash(message: &str) -> String {
 #[wasm_bindgen]
 pub fn validate_address(address: &str, network: u8) -> bool {
     let network = match u8_to_network(network) {
-        Ok(n) => n,
+        Ok(n) => network,
         Err(_) => return false,
     };
     
@@ -298,7 +298,7 @@ pub fn verify_signature(
     pubkey: &str,
 ) -> Result<bool, JsValue> {
     verify_signature(message, signature, pubkey)
-        .map_err(|e| JsValue::from_str(&format!("Signature verification failed: {}", e)))
+        .map_err(|e| JsValue::from_str(&format!("Signature verification failed: {:?}", e)))
 }
 
 /// Market analytics helper

--- a/yew-webapp/Cargo.toml
+++ b/yew-webapp/Cargo.toml
@@ -11,9 +11,13 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+markstr-core = { path = "../markstr-core" }
+
+# JSON 
 serde.workspace = true
 serde_json.workspace = true
 
+## Browser
 idb = { version = "0.6.4" }
 web-sys.workspace = true
 
@@ -22,9 +26,7 @@ yew = { version = "0.21.0", features = ["csr"] }
 yew-router = "0.18.0"
 
 # Nostr 
-nostr-minions = "0.1.18"
-
-# Wallet
+nostr-minions = "0.1.19"
 bitcoin.workspace = true
 bdk_wallet = { version = "1.2.0", features = ["keys-bip39"] }
 bdk_esplora = { version = "0.20.1", features = ["async-https-rustls", "tokio"], default-features = false }

--- a/yew-webapp/README.md
+++ b/yew-webapp/README.md
@@ -8,6 +8,7 @@ Before starting, install the following:
 - [Rust & Cargo](https://www.rust-lang.org/tools/install) 🦀
 - [Trunk](https://trunkrs.dev/#install) 🚀
 - [WebAssembly Target](https://rustwasm.github.io/wasm-pack/installer/) 🕸️
+- [TailwindCSS - V4](https://tailwindcss.com/docs/installation) 🦶
 
 ### 🔥 Run the Dev Server
 
@@ -17,5 +18,11 @@ To start the **Dev Server** from the workspace directory, execute:
 trunk serve --config yew-webapp/Trunk.toml
 ```
 App will be available at http://localhost:8080
+
+#### TailwindCSS
+
+The `Trunk.toml` file is used to configure the build process, including the `tailwindcss` command.
+
+If you use a custom `tailwindcss` command, you can modify the `Trunk.toml` file accordingly.
 
 

--- a/yew-webapp/Trunk.toml
+++ b/yew-webapp/Trunk.toml
@@ -1,4 +1,4 @@
 [[hooks]]
 stage = "pre_build"
 command = "sh"
-command_arguments = ["-c", "if [ \"$TRUNK_PROFILE\" = \"debug\" ]; then tailwindcss4 -i input.css -o output.css --minify; fi"]
+command_arguments = ["-c", "if [ \"$TRUNK_PROFILE\" = \"debug\" ]; then tailwindcss -i input.css -o output.css --minify; fi"]

--- a/yew-webapp/input.css
+++ b/yew-webapp/input.css
@@ -1,79 +1,50 @@
 @import "tailwindcss";
 @source "../src/**";
-@source "../../shady-minions/src/**";
 
-:root {
-    --background: hsl(60, 2%, 12%);
-    --foreground: hsl(0, 0%, 100%);
-    --primary: hsl(247, 95%, 45%);
-    --primary-foreground: hsl(0, 0%, 100%);
-
-    --secondary: hsl(74, 88%, 48%);
-    --secondary-foreground: hsl(0, 0%, 73%);
-    --destructive: hsl(0, 80%, 55%);
-
-    --muted: hsl(0, 0%, 73%);
-    --muted-foreground: hsl(0, 0%, 38%);
-    --accent: hsl(120, 2%, 18%);
-    --accent-foreground: hsl(140, 20%, 90%);
-
-    --border: hsl(60, 2%, 12%);
-    --input: hsl(0, 0%, 73%);
-    --ring: hsl(120, 2%, 18%);
+/* Custom scrollbar */
+::-webkit-scrollbar {
+  width: 8px;
 }
 
-.dark {
-    --background: hsl(60, 2%, 12%);
-    --foreground: hsl(0, 0%, 100%);
-    --primary: hsl(247, 95%, 45%);
-    --primary-foreground: hsl(0, 0%, 100%);
-
-    --secondary: hsl(74, 88%, 48%);
-    --secondary-foreground: hsl(0, 0%, 73%);
-    --destructive: hsl(0, 80%, 55%);
-
-    --muted: hsl(0, 0%, 73%);
-    --muted-foreground: hsl(0, 0%, 38%);
-    --accent: hsl(120, 2%, 18%);
-    --accent-foreground: hsl(140, 20%, 90%);
-
-    --border: hsl(0, 0%, 73%);
-    --input: hsl(0, 0%, 73%);
-    --ring: hsl(120, 2%, 18%);
+::-webkit-scrollbar-track {
+  background: #f1f1f1;
+  border: 1px solid #000;
 }
 
-@theme inline {
-    --color-background: var(--background);
-    --color-foreground: var(--foreground);
-    --color-primary: var(--primary);
-    --color-primary-foreground: var(--primary-foreground);
-    --color-secondary: var(--secondary);
-    --color-secondary-foreground: var(--secondary-foreground);
-    --color-destructive: var(--destructive);
-    --color-destructive-foreground: var(--background);
-    --color-muted: var(--muted);
-    --color-muted-foreground: var(--muted-foreground);
-    --color-accent: var(--accent);
-    --color-accent-foreground: var(--accent-foreground);
-    --color-border: var(--border);
-    --color-input: var(--input);
-    --color-ring: var(--ring);
+::-webkit-scrollbar-thumb {
+  background: #FF6B00;
+  border: 1px solid #000;
 }
 
-@theme {
-  --animate-loading-bar: fade-in-scale 1s ease-in-out infinite;
-  @keyframes fade-in-scale {
-    0% {
-      transform: translateX(-100%);
-    }
-    100% {
-      transform: translateX(200%);
-    }
+::-webkit-scrollbar-thumb:hover {
+  background: #e55a00;
+}
+
+/* Loading animation */
+.loading {
+  @apply animate-pulse;
+}
+
+.loading-dots::after {
+  content: '...';
+  animation: dots 2s infinite;
+}
+
+@keyframes dots {
+  0%, 20% {
+    content: '.';
+  }
+  40% {
+    content: '..';
+  }
+  60% {
+    content: '...';
+  }
+  80% {
+    content: '....';
+  }
+  100% {
+    content: '.....';
   }
 }
 
-@layer base {
-    img {
-        @apply inline;
-    }
-}

--- a/yew-webapp/src/components/layout.rs
+++ b/yew-webapp/src/components/layout.rs
@@ -23,9 +23,6 @@ pub enum Route {
     NotFound,
 }
 
-use yew::prelude::*;
-use yew_router::prelude::*;
-
 #[derive(Properties, PartialEq)]
 pub struct LayoutProps {
     #[prop_or_default]
@@ -38,18 +35,18 @@ pub fn layout(props: &LayoutProps) -> Html {
 
     let nav_items = vec![
         NavItem::new(Route::Dashboard, "Dashboard", "📊"),
-        NavItem::new(Route::Roles, "Roles", "👥"),
+        // NavItem::new(Route::Roles, "Roles", "👥"),
         NavItem::oracle(Route::CreateMarket, "Create Market", "🏦"),
         NavItem::new(Route::Betting, "Betting", "🎯"),
-        NavItem::oracle(Route::Oracle, "Oracle", "🔮"),
-        NavItem::new(Route::Payouts, "Payouts", "💰"),
+        // NavItem::oracle(Route::Oracle, "Oracle", "🔮"),
+        // NavItem::new(Route::Payouts, "Payouts", "💰"),
         NavItem::new(Route::Transactions, "Transactions", "📝"),
     ];
 
     let is_active = |route: &Route| route == &location;
 
     html! {
-        <div class="min-h-screen bg-gray-50">
+        <div class="h-screen min-h-screen bg-gray-50 overflow-hidden">
             // Header
             <header class="bg-white border-b-4 border-black shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
                 <div class="container mx-auto px-4 py-4">
@@ -73,11 +70,11 @@ pub fn layout(props: &LayoutProps) -> Html {
             </header>
 
             // Main layout
-            <div class="flex">
+            <div class="flex h-full">
                 // Sidebar
                 <aside class="w-64 bg-white border-r-4 border-black min-h-screen">
                     <nav class="p-4">
-                        <ul class="space-y-2">
+                        <ul class="space-y-5">
                             {
                                 for nav_items
                                     .into_iter()
@@ -127,7 +124,7 @@ pub fn layout(props: &LayoutProps) -> Html {
                 </aside>
 
                 // Main Content
-                <main class="flex-1 p-6">
+                <main class="flex-1 p-6 overflow-y-auto pb-28">
                     { for props.children.iter() }
                 </main>
             </div>

--- a/yew-webapp/src/components/market/market_creator.rs
+++ b/yew-webapp/src/components/market/market_creator.rs
@@ -1,0 +1,452 @@
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct FormData {
+    pub question: String,
+    pub outcomes: Vec<String>,
+    pub settlement_time: String,
+    pub description: String,
+}
+
+impl Default for FormData {
+    fn default() -> Self {
+        Self {
+            question: String::new(),
+            outcomes: vec!["Yes".to_string(), "No".to_string()],
+            settlement_time: String::new(),
+            description: String::new(),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Default)]
+pub struct FormErrors {
+    pub question: Option<String>,
+    pub outcomes: Option<String>,
+    pub settlement_time: Option<String>,
+}
+
+#[function_component(MarketCreator)]
+pub fn market_creator() -> Html {
+    let nostr_id = nostr_minions::key_manager::use_nostr_key();
+    let relay_ctx = nostr_minions::relay_pool::use_nostr_relay_pool();
+    let form_data = use_state(FormData::default);
+    let errors = use_state(FormErrors::default);
+    let loading = use_state(|| false);
+
+    // Check permissions (commented for you to implement)
+    // let has_permission = use_context::<RoleContext>()
+    //     .map(|ctx| ctx.has_permission("create_market"))
+    //     .unwrap_or(false);
+
+    // Uncomment and implement permission check
+    // if !has_permission {
+    //     return html! {
+    //         <div class="bg-red-400 border-4 border-black shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] p-6">
+    //             <h2 class="text-2xl font-bold mb-4 font-['Space_Grotesk']">{"❌ ACCESS DENIED"}</h2>
+    //             <p class="text-lg mb-4">{"Only oracles can create markets."}</p>
+    //             <button
+    //                 onclick={/* navigate to roles */}
+    //                 class="bg-white border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] px-4 py-2 font-bold hover:transform hover:translate-x-1 hover:translate-y-1 transition-all duration-200"
+    //             >
+    //                 {"SWITCH TO ORACLE"}
+    //             </button>
+    //         </div>
+    //     };
+    // }
+
+    let handle_input_change = {
+        let form_data = form_data.clone();
+        let errors = errors.clone();
+        Callback::from(move |e: Event| {
+            let input: HtmlInputElement = e.target_unchecked_into();
+            let name = input.name();
+            let value = input.value();
+
+            let mut new_form_data = (*form_data).clone();
+            match name.as_str() {
+                "question" => new_form_data.question = value,
+                "description" => new_form_data.description = value,
+                "settlementTime" => new_form_data.settlement_time = value,
+                _ => {}
+            }
+            form_data.set(new_form_data);
+
+            // Clear error when user starts typing
+            let mut new_errors = (*errors).clone();
+            match name.as_str() {
+                "question" => new_errors.question = None,
+                "settlementTime" => new_errors.settlement_time = None,
+                _ => {}
+            }
+            errors.set(new_errors);
+        })
+    };
+
+    let handle_outcome_change = {
+        let form_data = form_data.clone();
+        Callback::from(move |(index, value): (usize, String)| {
+            let mut new_form_data = (*form_data).clone();
+            if index < new_form_data.outcomes.len() {
+                new_form_data.outcomes[index] = value;
+                form_data.set(new_form_data);
+            }
+        })
+    };
+
+    let add_outcome = {
+        let form_data = form_data.clone();
+        Callback::from(move |_| {
+            let mut new_form_data = (*form_data).clone();
+            if new_form_data.outcomes.len() < 5 {
+                new_form_data.outcomes.push(String::new());
+                form_data.set(new_form_data);
+            }
+        })
+    };
+
+    let remove_outcome = {
+        let form_data = form_data.clone();
+        Callback::from(move |index: usize| {
+            let mut new_form_data = (*form_data).clone();
+            if new_form_data.outcomes.len() > 2 {
+                new_form_data.outcomes.remove(index);
+                form_data.set(new_form_data);
+            }
+        })
+    };
+
+    let validate_form = {
+        let form_data = form_data.clone();
+        let errors = errors.clone();
+        Callback::from(move |_| {
+            let mut new_errors = FormErrors::default();
+            let data = &*form_data;
+            web_sys::console::log_1(&format!("{:?}", data).into());
+
+            if data.question.trim().is_empty() {
+                new_errors.question = Some("Question is required".to_string());
+            }
+
+            if data.settlement_time.is_empty() {
+                new_errors.settlement_time = Some("Settlement time is required".to_string());
+            } else {
+                // Add datetime validation logic here
+                // let settlement_time = data.settlement_time.parse::<u64>().unwrap();
+                // if data.settlement_time <= web_sys::js_sys::Date::new_0().to_string() {
+                //     new_errors.settlement_time =
+                //         Some("Settlement time must be in the future".to_string());
+                // }
+            }
+
+            if data.outcomes.iter().any(|o| o.trim().is_empty()) {
+                new_errors.outcomes = Some("All outcomes must be filled".to_string());
+            }
+
+            if data.outcomes.len() < 2 {
+                new_errors.outcomes = Some("At least 2 outcomes are required".to_string());
+            }
+
+            let is_valid = new_errors.question.is_none()
+                && new_errors.settlement_time.is_none()
+                && new_errors.outcomes.is_none();
+
+            errors.set(new_errors);
+            is_valid
+        })
+    };
+
+    let handle_submit = {
+        let validate_form = validate_form.clone();
+        let loading = loading.clone();
+        let form_data = form_data.clone();
+        let nostr_id = nostr_id.clone();
+        Callback::from(move |e: SubmitEvent| {
+            e.prevent_default();
+
+            if !validate_form.emit(()) {
+                return;
+            }
+            let Some(nostr_key) = nostr_id.as_ref() else {
+                return;
+            };
+
+            loading.set(true);
+
+            // Implement market creation logic here
+            let settlement_time = web_sys::js_sys::Date::parse(&form_data.settlement_time);
+            let outcomes: Vec<String> = form_data
+                .outcomes
+                .iter()
+                .filter(|o| !o.trim().is_empty())
+                .cloned()
+                .collect();
+            // let market = markstr_core::PredictionMarket::new(question, outcome_a, outcome_b, oracle_pubkey, settlement_timestamp)
+            let Ok(market) = markstr_core::PredictionMarket::new(
+                form_data.question.clone(),
+                outcomes[0].clone(),
+                outcomes[1].clone(),
+                nostr_key.public_key(),
+                settlement_time.trunc() as u64,
+            ) else {
+                loading.set(false);
+                return;
+            };
+
+            let mut market_event = nostr_minions::nostro2::NostrNote {
+                content: serde_json::to_string(&market).unwrap(),
+                kind: 39812,
+                ..Default::default()
+            };
+            market_event.tags.add_parameter_tag(&market.market_id);
+
+            nostr_key
+                .sign_note(&mut market_event)
+                .expect("Failed to sign market event");
+
+            let _ = relay_ctx.send(market_event);
+
+            loading.set(false);
+        })
+    };
+
+    let handle_cancel = Callback::from(|_| {
+        // Implement navigation to home
+        // navigate("/");
+    });
+
+    let get_min_datetime = || {
+        // Implement getting current time + 30 minutes
+        let now = web_sys::js_sys::Date::new_0();
+        now.set_minutes(now.get_minutes() + 30);
+        // format datetime for input
+        now.to_string().as_string().unwrap_or_default()
+    };
+
+    html! {
+        <div class="space-y-6">
+            // Header
+            <div class="bg-white border-4 border-black shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] p-6">
+                <h2 class="text-2xl font-bold mb-2 font-['Space_Grotesk']">{"🏦 CREATE MARKET"}</h2>
+                <p class="text-gray-600">
+                    {"Create a new prediction market as an oracle"}
+                </p>
+            </div>
+
+            // Form
+            <div class="bg-white border-4 border-black shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] p-6">
+                <form onsubmit={handle_submit} class="space-y-6">
+                    // Question
+                    <div>
+                        <label class="block text-lg font-bold mb-2 font-['Space_Grotesk']">
+                            {"Market Question *"}
+                        </label>
+                        <input
+                            type="text"
+                            name="question"
+                            value={form_data.question.clone()}
+                            onchange={handle_input_change.clone()}
+                            placeholder="e.g., Will Bitcoin reach $100k by end of 2024?"
+                            class="w-full p-3 border-2 border-black font-mono text-lg focus:outline-none focus:ring-2 focus:ring-orange-400"
+                            maxlength="200"
+                        />
+                        {
+                            if let Some(error) = &errors.question {
+                                html! { <p class="text-red-600 text-sm mt-1">{error}</p> }
+                            } else {
+                                html! {}
+                            }
+                        }
+                        <p class="text-sm text-gray-500 mt-1">
+                            {format!("{}/200 characters", form_data.question.len())}
+                        </p>
+                    </div>
+
+                    // Description
+                    <div>
+                        <label class="block text-lg font-bold mb-2 font-['Space_Grotesk']">
+                            {"Description (Optional)"}
+                        </label>
+                        <textarea
+                            name="description"
+                            value={form_data.description.clone()}
+                            onchange={handle_input_change.clone()}
+                            placeholder="Additional context or rules for the market..."
+                            class="w-full p-3 border-2 border-black font-mono text-sm focus:outline-none focus:ring-2 focus:ring-orange-400"
+                            rows="3"
+                            maxlength="500"
+                        />
+                        <p class="text-sm text-gray-500 mt-1">
+                            {format!("{}/500 characters", form_data.description.len())}
+                        </p>
+                    </div>
+
+                    // Outcomes
+                    <div>
+                        <label class="block text-lg font-bold mb-2 font-['Space_Grotesk']">
+                            {"Possible Outcomes *"}
+                        </label>
+                        {
+                            form_data.outcomes.iter().enumerate().map(|(index, outcome)| {
+                                let handle_outcome_change = handle_outcome_change.clone();
+                                let remove_outcome = remove_outcome.clone();
+                                let can_remove = form_data.outcomes.len() > 2;
+
+                                html! {
+                                    <div key={index} class="flex items-center mb-2">
+                                        <input
+                                            type="text"
+                                            value={outcome.clone()}
+                                            onchange={
+                                                let handle_outcome_change = handle_outcome_change.clone();
+                                                Callback::from(move |e: Event| {
+                                                    let input: HtmlInputElement = e.target_unchecked_into();
+                                                    handle_outcome_change.emit((index, input.value()));
+                                                })
+                                            }
+                                            placeholder={format!("Outcome {}", index + 1)}
+                                            class="flex-1 p-3 border-2 border-black font-mono text-lg focus:outline-none focus:ring-2 focus:ring-orange-400"
+                                            maxlength="50"
+                                        />
+                                        {
+                                            if can_remove {
+                                                html! {
+                                                    <button
+                                                        type="button"
+                                                        onclick={
+                                                            let remove_outcome = remove_outcome.clone();
+                                                            Callback::from(move |_| remove_outcome.emit(index))
+                                                        }
+                                                        class="ml-2 bg-red-400 border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] px-3 py-3 font-bold hover:transform hover:translate-x-1 hover:translate-y-1 transition-all duration-200"
+                                                    >
+                                                        {"❌"}
+                                                    </button>
+                                                }
+                                            } else {
+                                                html! {}
+                                            }
+                                        }
+                                    </div>
+                                }
+                            }).collect::<Html>()
+                        }
+                        {
+                            if form_data.outcomes.len() < 5 {
+                                html! {
+                                    <button
+                                        type="button"
+                                        onclick={add_outcome}
+                                        class="bg-green-400 border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] px-4 py-2 font-bold hover:transform hover:translate-x-1 hover:translate-y-1 transition-all duration-200"
+                                    >
+                                        {"+ ADD OUTCOME"}
+                                    </button>
+                                }
+                            } else {
+                                html! {}
+                            }
+                        }
+                        {
+                            if let Some(error) = &errors.outcomes {
+                                html! { <p class="text-red-600 text-sm mt-1">{error}</p> }
+                            } else {
+                                html! {}
+                            }
+                        }
+                    </div>
+
+                    // Settlement Time
+                    <div>
+                        <label class="block text-lg font-bold mb-2 font-['Space_Grotesk']">
+                            {"Settlement Time *"}
+                        </label>
+                        <input
+                            type="datetime-local"
+                            name="settlementTime"
+                            value={form_data.settlement_time.clone()}
+                            onchange={handle_input_change.clone()}
+                            min={get_min_datetime()}
+                            class="w-full p-3 border-2 border-black font-mono text-lg focus:outline-none focus:ring-2 focus:ring-orange-400"
+                        />
+                        {
+                            if let Some(error) = &errors.settlement_time {
+                                html! { <p class="text-red-600 text-sm mt-1">{error}</p> }
+                            } else {
+                                html! {}
+                            }
+                        }
+                        <p class="text-sm text-gray-500 mt-1">
+                            {"When the market will be settled and the outcome determined"}
+                        </p>
+                    </div>
+
+                    // Preview
+                    <div class="bg-gray-100 border-2 border-black p-4">
+                        <h3 class="text-lg font-bold mb-2 font-['Space_Grotesk']">{"📋 PREVIEW"}</h3>
+                        <div class="space-y-2">
+                            <div>
+                                <strong>{"Question: "}</strong>
+                                {
+                                    if form_data.question.is_empty() {
+                                        "No question set"
+                                    } else {
+                                        &form_data.question
+                                    }
+                                }
+                            </div>
+                            <div>
+                                <strong>{"Outcomes: "}</strong>
+                                // {
+                                //     let outcomes: Vec<&str> = form_data.outcomes.iter()
+                                //         .filter(|o| !o.trim().is_empty())
+                                //         .map(|s| s.as_str())
+                                //         .collect();
+                                //     if outcomes.is_empty() {
+                                //         "No outcomes set".to_string()
+                                //     } else {
+                                //         outcomes.join(", ")
+                                //     }
+                                // }
+                            </div>
+                            <div>
+                                <strong>{"Settlement: "}</strong>
+                                {
+                                    if form_data.settlement_time.is_empty() {
+                                        "No time set"
+                                    } else {
+                                        // Format the datetime string for display
+                                        &form_data.settlement_time
+                                    }
+                                }
+                            </div>
+                        </div>
+                    </div>
+
+                    // Submit Button
+                    <div class="flex items-center justify-between">
+                        <button
+                            type="button"
+                            onclick={handle_cancel}
+                            class="bg-gray-400 border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] px-6 py-3 font-bold hover:transform hover:translate-x-1 hover:translate-y-1 transition-all duration-200"
+                        >
+                            {"CANCEL"}
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={*loading}
+                            class="bg-orange-400 border-2 border-black shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] px-6 py-3 font-bold hover:transform hover:translate-x-1 hover:translate-y-1 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            {
+                                if *loading {
+                                    "CREATING..."
+                                } else {
+                                    "CREATE MARKET"
+                                }
+                            }
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    }
+}

--- a/yew-webapp/src/components/market/market_list.rs
+++ b/yew-webapp/src/components/market/market_list.rs
@@ -1,0 +1,261 @@
+use std::collections::HashMap;
+use web_sys::js_sys::Date;
+use yew::prelude::*;
+
+
+#[function_component(BettingPage)]
+pub fn betting_page() -> Html {
+    html! {
+        <div class="space-y-6">
+            <div class="p-6 bg-white border-4 border-black shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+                <h2 class="text-2xl font-bold mb-2 font-[Space_Grotesk]">{"🎯 PLACE BET"}</h2>
+                <p class="text-gray-600">
+                    {"Create a new prediction market as an oracle"}
+                </p>
+            </div>
+            <MarketList />
+        </div>
+    }
+}
+
+#[derive(Properties, PartialEq)]
+pub struct MarketListProps {
+    #[prop_or(None)]
+    pub status: Option<bool>,
+    #[prop_or(None)]
+    pub limit: Option<usize>,
+}
+
+#[function_component(MarketList)]
+pub fn market_list(props: &MarketListProps) -> Html {
+    let markets = crate::context::use_market_list();
+    let filtered_markets = use_state(Vec::<markstr_core::PredictionMarket>::new);
+
+    // Effect to filter markets
+    {
+        let filtered_markets = filtered_markets.clone();
+        let status = props.status;
+        let limit = props.limit;
+
+        use_effect_with(markets.clone(), move |markets| {
+
+            let mut filtered = if let Some(status) = status {
+                markets
+                    .iter()
+                    .filter(|market| market.settled == status)
+                    .cloned()
+                    .collect()
+            } else {
+                markets.clone()
+            };
+
+            if let Some(limit_val) = limit {
+                filtered.truncate(limit_val);
+            }
+            web_sys::console::log_1(&format!("Filtered markets: {filtered:?}").into());
+
+            filtered_markets.set(filtered);
+        });
+    }
+
+    // Helper functions
+    let get_status_color = |status: bool, bets: &[markstr_core::Bet]| -> &str {
+        if status {
+            "bg-gray-400"
+        } else if bets.is_empty() {
+            "bg-blue-400"
+        } else if bets.iter().any(|bet| bet.amount > 0) {
+            "bg-yellow-400"
+        } else {
+            "bg-green-400"
+        }
+        // match status {
+        //     "active" => "bg-green-400",
+        //     "funded" => "bg-yellow-400",
+        //     "settled" => "bg-gray-400",
+        //     "created" => "bg-blue-400",
+        //     _ => "bg-gray-400",
+        // }
+    };
+
+    let get_status_text = |status: bool, bets: &[markstr_core::Bet]| -> &str {
+        if status {
+            "🟢 SETTLED"
+        } else if bets.is_empty() {
+            "🔵 CREATED"
+        } else if bets.iter().any(|bet| bet.amount > 0) {
+            "🟡 FUNDED"
+        } else {
+            "⚫ ACTIVE"
+        }
+    };
+
+    let format_time_remaining = |end_time: f64| -> String {
+        let now = Date::now();
+        let remaining = end_time - now;
+
+        if remaining <= 0.0 {
+            return "Expired".to_string();
+        }
+
+        let days = (remaining / (1000.0 * 60.0 * 60.0 * 24.0)).floor() as i32;
+        let hours =
+            ((remaining % (1000.0 * 60.0 * 60.0 * 24.0)) / (1000.0 * 60.0 * 60.0)).floor() as i32;
+
+        if days > 0 {
+            format!("{}d {}h", days, hours)
+        } else {
+            format!("{}h", hours)
+        }
+    };
+
+    let calculate_odds = |market: &markstr_core::PredictionMarket| -> HashMap<String, String> {
+        let mut odds = HashMap::new();
+
+        // for outcome in &market.outcomes {
+        //     let outcome_amount: f64 = market
+        //         .bets
+        //         .iter()
+        //         .filter(|bet| bet.outcome == *outcome)
+        //         .map(|bet| bet.amount)
+        //         .sum();
+
+        //     let percentage = if market.total_pool > 0.0 {
+        //         (outcome_amount / market.total_pool * 100.0)
+        //     } else {
+        //         0.0
+        //     };
+
+        //     odds.insert(outcome.clone(), format!("{:.1}", percentage));
+        // }
+
+        odds
+    };
+
+    // Render empty state
+    if filtered_markets.is_empty() {
+        return html! {
+            <crate::components::Card class="p-6 text-center">
+                <div class="text-4xl mb-4">{"🏪"}</div>
+                <p class="text-gray-500 mb-4">{"No markets found"}</p>
+                <p class="text-sm text-gray-400">
+                    {
+                        "No markets available yet"
+                        // if let Some(status) = props.status {
+                        //     "No markets available yet"
+                        // } else {
+                        //     &format!("No markets found", props.status)
+                        // }
+                    }
+                </p>
+            </crate::components::Card>
+        };
+    }
+
+    // Render markets
+    html! {
+        <div class="space-y-4">
+            {
+                filtered_markets.iter().map(|market| {
+                    let odds = calculate_odds(market);
+                    let market_id = market.market_id.clone();
+                    let bets = [market.bets_a.clone(), market.bets_b.clone()].concat();
+
+                    html! {
+                        <crate::components::Card key={market.market_id.clone()} class="p-4">
+                            <div class="flex items-start justify-between mb-3">
+                                <div class="flex-1">
+                                    <h4 class="font-bold text-lg font-['Space_Grotesk'] mb-2">
+                                        {&market.question}
+                                    </h4>
+                                    <div class="flex items-center space-x-4">
+                                        <span class={format!("{} px-2 py-1 border border-black text-xs font-bold",
+                                            get_status_color(market.settled, &bets))}>
+                                            {get_status_text(market.settled, &bets)}
+                                        </span>
+                                        <span class="text-sm font-mono">
+                                            {format!("Pool: {} BTC", market.total_amount)}
+                                        </span>
+                                        <span class="text-sm">
+                                            {format!("⏰ {}", format_time_remaining(market.settlement_timestamp as f64))}
+                                        </span>
+                                        <span class="text-sm">
+                                            {format!("🎯 {} bets", bets.len())}
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="flex space-x-2">
+                                    <a href={format!("/betting/{}", market.market_id)}>
+                                        <crate::components::Button variant={crate::components::ButtonVariant::Secondary}
+                                        size={crate::components::ButtonSize::Small}>
+                                            {"VIEW"}
+                                        </crate::components::Button>
+                                    </a>
+                                    {
+                                        if !market.settled {
+                                            html! {
+                                                <a href={format!("/betting/{}", market.market_id)}>
+                                                    <crate::components::Button
+                                                    variant={crate::components::ButtonVariant::Primary}
+                                                    size={crate::components::ButtonSize::Small}>
+                                                        {"BET"}
+                                                    </crate::components::Button>
+                                                </a>
+                                            }
+                                        } else {
+                                            html! {}
+                                        }
+                                    }
+                                </div>
+                            </div>
+
+                            // Outcomes
+                            <div class="grid grid-cols-1 md:grid-cols-3 gap-2">
+                                //{
+                                    // market.outcomes.iter().map(|outcome| {
+                                    //     let outcome_odds = odds.get(outcome).unwrap_or(&"0.0".to_string()).clone();
+
+                                    //     html! {
+                                    //         <div key={outcome.clone()} class="border border-black p-2 bg-white">
+                                    //             <div class="flex justify-between items-center">
+                                    //                 <span class="font-semibold">{outcome}</span>
+                                    //                 <span class="text-sm font-mono">{format!("{}%", outcome_odds)}</span>
+                                    //             </div>
+                                    //             {
+                                    //                 if market.status == "settled" &&
+                                    //                    market.winning_outcome.as_ref() == Some(outcome) {
+                                    //                     html! {
+                                    //                         <span class="text-xs bg-green-400 px-2 py-1 border border-black mt-1 inline-block">
+                                    //                             {"🏆 WINNER"}
+                                    //                         </span>
+                                    //                     }
+                                    //                 } else {
+                                    //                     html! {}
+                                    //                 }
+                                    //             }
+                                    //         </div>
+                                    //     }
+                                    // }).collect::<Html>()
+                                //}
+                            </div>
+
+                            // Additional Info
+                            <div class="mt-3 pt-3 border-t border-gray-300">
+                                <div class="flex justify-between items-center text-sm text-gray-600">
+                                    <span>{format!("Market ID: {}", market.market_id)}</span>
+                                    <span>
+                                        //{format!("Created: {}",
+                                        //    Date::new(&(market.settlement_timestamp).into())
+                                        //        .to_locale_date_string("en-US", &web_sys::js_sys::Object::new())
+                                        //)}
+                                    </span>
+                                </div>
+                            </div>
+                        </crate::components::Card>
+                    }
+                }).collect::<Html>()
+            }
+        </div>
+    }
+}
+

--- a/yew-webapp/src/components/market/mod.rs
+++ b/yew-webapp/src/components/market/mod.rs
@@ -1,0 +1,5 @@
+mod market_creator;
+mod market_list;
+
+pub use market_creator::*;
+pub use market_list::*;

--- a/yew-webapp/src/components/mod.rs
+++ b/yew-webapp/src/components/mod.rs
@@ -1,7 +1,11 @@
 mod dashboard;
 mod layout;
+mod market;
 mod ui;
+mod wallet;
 
 pub use dashboard::*;
 pub use layout::*;
+pub use market::*;
 pub use ui::*;
+pub use wallet::*;

--- a/yew-webapp/src/components/wallet/mod.rs
+++ b/yew-webapp/src/components/wallet/mod.rs
@@ -1,0 +1,3 @@
+mod transactions;
+
+pub use transactions::*;

--- a/yew-webapp/src/components/wallet/transactions.rs
+++ b/yew-webapp/src/components/wallet/transactions.rs
@@ -1,0 +1,56 @@
+use yew::prelude::*;
+
+#[function_component(TransactionsPage)]
+pub fn transactions_page() -> Html {
+    html! {
+        <div class="space-y-6">
+            <div class="p-6 bg-white border-4 border-black shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+                <h2 class="text-2xl font-bold mb-2 font-[Space_Grotesk]">{"📝 TRANSACTION HISTORY"}</h2>
+                <p class="text-gray-600">
+                    {"View transaction history"}
+                </p>
+            </div>
+            <Transactions />
+        </div>
+    }
+}
+
+#[function_component(Transactions)]
+pub fn transactions() -> Html {
+    let transactions = crate::context::use_wallet_transactions();
+
+    html! {
+        <div class="space-y-5">
+            {
+                transactions.iter().map(|(tx, _)| {
+                    let txid = tx.compute_txid();
+                    let amount = tx.output[0].value;
+                    let address = bitcoin::Address::from_script(&tx.output[0].script_pubkey, bitcoin::Network::Signet).map(|a| a.to_string()).unwrap_or_default();
+                    html! {
+                        <crate::components::Card class="p-4 font-['Space_Grotesk'] flex justify-evenly items-center">
+                            <div class="flex justify-between items-center w-3/4">
+                                <span class="font-semibold">{"Transaction ID:"}</span>
+                                <span class="font-mono">{ txid.to_string() }</span>
+                            </div>
+                            <a href={format!("https://mutinynet.com/tx/{}", txid)} target="_blank">
+                                <crate::components::Button 
+                                    variant={crate::components::ButtonVariant::Secondary}
+                                    size={crate::components::ButtonSize::Small}>
+                                    {"VIEW"}
+                                </crate::components::Button>
+                            </a>
+                            // <div class="flex justify-between items-center">
+                            //     <span class="font-semibold">{"Amount:"}</span>
+                            //     <span class="font-mono">{ format!("{} BTC", amount) }</span>
+                            // </div>
+                            // <div class="flex justify-between items-center">
+                            //     <span class="font-semibold">{"Address:"}</span>
+                            //     <span class="font-mono">{ address }</span>
+                            // </div>
+                        </crate::components::Card>
+                    }
+                }).collect::<Html>()
+            }
+        </div>
+    }
+}

--- a/yew-webapp/src/context/market/mod.rs
+++ b/yew-webapp/src/context/market/mod.rs
@@ -1,0 +1,3 @@
+mod provider;
+
+pub use provider::*;

--- a/yew-webapp/src/context/market/provider.rs
+++ b/yew-webapp/src/context/market/provider.rs
@@ -1,0 +1,135 @@
+use yew::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PredictionMarket {
+    loaded: bool,
+    synced: bool,
+    markets: Vec<nostr_minions::nostro2::NostrNote>,
+}
+impl PredictionMarket {
+    pub fn loaded(&self) -> bool {
+        self.loaded
+    }
+    pub fn synced(&self) -> bool {
+        self.synced
+    }
+}
+
+pub enum PredictionMarketAction {
+    Loaded,
+    Synced,
+    NewMarket(nostr_minions::nostro2::NostrNote),
+}
+
+impl Reducible for PredictionMarket {
+    type Action = PredictionMarketAction;
+
+    fn reduce(self: std::rc::Rc<Self>, action: Self::Action) -> std::rc::Rc<Self> {
+        match action {
+            PredictionMarketAction::Loaded => {
+                web_sys::console::log_1(&"Wallet loaded".into());
+                std::rc::Rc::new(Self {
+                    loaded: true,
+                    synced: self.synced,
+                    markets: self.markets.clone(),
+                })
+            }
+            PredictionMarketAction::Synced => {
+                web_sys::console::log_1(&"Wallet synced".into());
+                std::rc::Rc::new(Self {
+                    loaded: self.loaded,
+                    synced: true,
+                    markets: self.markets.clone(),
+                })
+            }
+            PredictionMarketAction::NewMarket(market) => {
+                web_sys::console::log_1(&format!("New market: {market:?}").into());
+                let mut markets = self.markets.clone();
+                markets.push(market);
+                std::rc::Rc::new(Self {
+                    loaded: self.loaded,
+                    synced: self.synced,
+                    markets,
+                })
+            }
+        }
+    }
+}
+
+pub type PredictionMarketStore = UseReducerHandle<PredictionMarket>;
+
+#[function_component(MarketProvider)]
+pub fn market_provider(props: &yew::html::ChildrenProps) -> HtmlResult {
+    let ctx = use_reducer(|| PredictionMarket {
+        loaded: false,
+        synced: false,
+        markets: Vec::new(),
+    });
+    let relay_ctx = nostr_minions::relay_pool::use_nostr_relay_pool();
+    let nostr_id = nostr_minions::key_manager::use_nostr_key();
+
+    let sub_id = use_state(|| None);
+
+    let relay_ctx_clone = relay_ctx.clone();
+    let id_setter = sub_id.setter();
+    use_memo((), move |_| {
+        let market_filter = nostr_minions::nostro2::NostrSubscription {
+            kinds: vec![39812].into(),
+            ..Default::default()
+        };
+        if let nostr_minions::nostro2::NostrClientEvent::Subscribe(_, new_sub_id, ..) =
+            relay_ctx_clone.send(market_filter)
+        {
+            id_setter.set(Some(new_sub_id));
+        }
+    });
+
+    let ctx_dispatcher = ctx.dispatcher();
+    use_effect_with(relay_ctx.relay_events.clone(), move |notes| {
+        if let Some(nostr_minions::nostro2::NostrRelayEvent::EndOfSubscription(.., sub_id_notice)) =
+            notes.last()
+        {
+            if Some(sub_id_notice) == sub_id.as_ref() {
+                ctx_dispatcher.dispatch(PredictionMarketAction::Loaded);
+            }
+        }
+        || {}
+    });
+
+    let ctx_dispatcher = ctx.dispatcher();
+    use_effect_with(relay_ctx.unique_notes.clone(), move |notes| {
+        let run = || {
+            let Some(last_note) = notes.last() else {
+                return;
+            };
+            if last_note.kind != 39812 {
+                return;
+            }
+            if serde_json::from_str::<markstr_core::PredictionMarket>(&last_note.content).is_ok() {
+                web_sys::console::log_1(&"New market received".into());
+                ctx_dispatcher.dispatch(PredictionMarketAction::NewMarket(last_note.clone()));
+            }
+        };
+        run();
+        || {}
+    });
+
+    Ok(html! {
+        <ContextProvider<PredictionMarketStore> context={ctx}>
+            {props.children.clone()}
+        </ContextProvider<PredictionMarketStore>>
+    })
+}
+
+#[hook]
+pub fn use_market_list() -> Vec<markstr_core::PredictionMarket> {
+    let Some(ctx) = use_context::<PredictionMarketStore>() else {
+        return vec![];
+    };
+    ctx.markets
+        .iter()
+        .filter_map(|market| {
+            serde_json::from_str::<markstr_core::PredictionMarket>(&market.content).ok()
+        })
+        .collect()
+}

--- a/yew-webapp/src/context/mod.rs
+++ b/yew-webapp/src/context/mod.rs
@@ -1,3 +1,5 @@
+mod market;
 mod wallet;
 
+pub use market::*;
 pub use wallet::*;

--- a/yew-webapp/src/main.rs
+++ b/yew-webapp/src/main.rs
@@ -37,13 +37,15 @@ fn app_content() -> Html {
         <nostr_minions::relay_pool::NostrRelayPoolProvider {relays}>
             <nostr_minions::key_manager::NostrIdProvider>
             <context::WalletProvider>
+            <context::MarketProvider>
             <components::Layout>
                 <KeyCheck>
-                <WalletLoad>
-                <components::Dashboard />
-                </WalletLoad>
+                    <WalletLoad>
+                        <Router />
+                    </WalletLoad>
                 </KeyCheck>
             </components::Layout>
+            </context::MarketProvider>
             </context::WalletProvider>
             </nostr_minions::key_manager::NostrIdProvider>
         </nostr_minions::relay_pool::NostrRelayPoolProvider>
@@ -117,5 +119,34 @@ fn wallet_load(props: &yew::html::ChildrenProps) -> HtmlResult {
         false => Ok(html! {
             <components::LoadingSpinner />
         }),
+    }
+}
+
+#[function_component(Router)]
+fn router() -> Html {
+    html! {
+        <yew_router::Switch<components::Route> render = { move |switch: components::Route| {
+            match switch {
+                components::Route::Dashboard => html! {
+                    <components::Dashboard />
+                },
+                components::Route::CreateMarket => html! {
+                    <components::MarketCreator />
+                },
+                components::Route::Betting  => html! {
+                    <components::BettingPage />
+                },
+                components::Route::Transactions => html! {
+                    <components::TransactionsPage />
+                },
+                _ => html! {
+                    <div class="flex flex-1 items-center justify-center">
+                        <div class="text-3xl font-bold text-black font-['Space_Grotesk']">{ "404" }</div>
+                        <div class="text-xl font-bold text-black font-['Space_Grotesk']">{ "Page not found" }</div>
+                    </div>
+                }
+            }
+        }}
+        />
     }
 }


### PR DESCRIPTION
- Market Creation

Added a market creation page to the `yew-webapp`.
Does basic sanity checks on the market details, then posts the market to Nostr relays.

- Market List

Added a market list page to the `yew-webapp`.
Lists all markets on the network.

- Transactions

Added a transactions page to the `yew-webapp`.
Lists all transactions for the wallet, and links to the transaction details on Mutinynet mempool.

- Core changes

Removes dependency on `nostr` crate for `PredictionMarket` and `Bet` structs, to integrate in to yew-webapp. Open to suggestions on how to integrate this.